### PR TITLE
Update hosts for viewer tool

### DIFF
--- a/tools/viewer.html
+++ b/tools/viewer.html
@@ -22,9 +22,7 @@ function create()
 		area.style.display = 'none';
 		area.innerHTML = '';
 		a.innerHTML = '';
-		
-		var link = 'https://www.draw.io';
-		
+
 		if (url.substring(0, 32) == 'https://drive.google.com/file/d/')
 		{
 			var id = url.substring(32, url.lastIndexOf('/'));
@@ -33,16 +31,19 @@ function create()
 		
 		if (document.getElementById('iframe').checked)
 		{
+			var link = 'https://viewer.diagrams.net';
 			area.style.display = '';
 			area.appendChild(document.createTextNode(
 				'<iframe frameborder="0" style="width:100%;height:' +
 				document.getElementById('height').value + ';" src="' +
-				link + '?lightbox=1#U' + encodeURIComponent(url) + '"></iframe>'));
+				link + '?#U' + encodeURIComponent(url) + '"></iframe>'));
 			area.focus();
 			document.execCommand('selectAll');
 		}
 		else
 		{
+			var link = 'https://app.diagrams.net';
+
 			if (document.getElementById('lightbox').checked)
 			{
 				link += '?lightbox=1&edit=_blank';


### PR DESCRIPTION
I ran across this looking into embedding options and it looked like it might need an update. On the latest Chrome browser at least I was hitting:

> Refused to frame 'https://app.diagrams.net/' because an ancestor violates the following Content Security Policy directive: "frame-ancestors 'self' https://teams.microsoft.com".

Consider this PR more of an issue report, but these changes seemed to address the issue, based on the latest embed options in the main app at app.diagrams.net. Thanks for the great tool!